### PR TITLE
Two changes on the css and ruby configs

### DIFF
--- a/css/.stickler.yml
+++ b/css/.stickler.yml
@@ -1,3 +1,2 @@
 linters:
   stylelint:
-  csslint:

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,0 +1,8 @@
+# Commonly used screens these days easily fit more than 80 characters.
+Metrics/LineLength:
+  Max: 120
+
+# Too short methods lead to extraction of single-use methods, which can make
+# the code easier to read (by naming things), but can also clutter the class
+Metrics/MethodLength: 
+  Max: 20

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -4,5 +4,6 @@ Metrics/LineLength:
 
 # Too short methods lead to extraction of single-use methods, which can make
 # the code easier to read (by naming things), but can also clutter the class
-Metrics/MethodLength: 
+Metrics/MethodLength:
+  Include: ["app/controllers/*"]
   Max: 20


### PR DESCRIPTION
**remove the csslint**  
Many new properties in CSS3 are not recognized in CSSLint and many cases approved by W3 validator are not tolerated in this linter, it will overwhelm students who will waste a lot of time trying to solve every error before realizing they shouldn't use this linter in the first place

**Create .rubocop.yml** 
This will allow students to have more room in the functions and line length, the first is necessary most of the time and the later becomes very handy while trying to test your functions on big arrays.
