### PR TITLE
Excluded method :describe from the BlockLength

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -7,3 +7,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Include: ["app/controllers/*"]
   Max: 20
+
+Metrics/BlockLength:
+  ExcludedMethods: ['describe']


### PR DESCRIPTION
- :describe method in RSpec usually need blocks longer than 25 lines to describe the behavior of a whole class with its methods and contexts and examples.

- Excluding :describe specifically doesn't encourage any bad practices.

- The alternative is to divide the class into multiple :describe methods, which is not ideal.

Theoretically, :context can also need longer blocks in rails applications, but I suggest changes when I discover the need to, hence the incremental spamming of this repository :)