### PR TITLE
Replace the word rubocob with stylelint

### DIFF
--- a/css/README.md
+++ b/css/README.md
@@ -16,7 +16,7 @@ Please do the following **steps in this order**:
 
 1. `while scanning for the next token found character '\t' that cannot start any token` error.
     Please make sure that you used spaces not tabs for indentation.
-2. Stickler does not work and nothing helps 💥 - run rubocop in your local env:
+2. Stickler does not work and nothing helps 💥 - run [stylelint](https://stylelint.io/) in your local env:
     - run `npm install stylelint stylelint-config-recommended --save-dev`  (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm))
     - copy [stylelint.config.js](./stylelint.config.js) to the root directory of your project
     - run `npx stylelint .`


### PR DESCRIPTION
./css/README.md refers to rubocop when it is talking about stylelint.

This pull request replaces the word 'rubocop' with 'stylelint' as it is
referring to the later.

Also a link to stylelint docs can be helpful, so the link is added.