### PR TITLE
Javascript link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Each directory contains Stickler's config files specific to one programming lang
 
 - [css](./css)
 - [ruby](./ruby)
-- [javascript](./ruby)
+- [javascript](./javascript)
 
 Follow those instructions in order to set up Stickler in your repo.
 


### PR DESCRIPTION
Hi @nidalaa 
For javascript stickler instruction by mistakenly there was `./ruby`. Now it fixed.