### PR TITLE
updates dir exclusion matcher

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,8 +1,8 @@
 AllCops:
   Exclude:
     - "bin/*"
-    - "db/*"
-    - "config/*"
+    - "db/**/*"
+    - "config/**/*"
     - "Guardfile"
     - "Rakefile"
   DisplayCopNames: true


### PR DESCRIPTION
I noticed that rubocop wasn't properly excluding the files in `db/` and `config/` directories.

I check the [docs](https://rubocop.readthedocs.io/en/stable/configuration/#includingexcluding-files) and found the correct format to be `root_dir/**/*`