### PR TITLE
add rule to ignore dist directory for stickler

### DIFF
--- a/javascript/.stickler.yml
+++ b/javascript/.stickler.yml
@@ -1,3 +1,6 @@
 linters:
   eslint:
     config: './eslint.config'
+files:
+  ignore:
+      - 'dist/*'


### PR DESCRIPTION
Given that webpack would always generate the final JavaScript file in one line with many other efforts to make the final js file light-weight; it makes the final build fail a lot, if not, all ESLint rules.

So, I thought it best we exclude it for stickler. This way, the students won't have a need to tinker with the configuration.

CC: @nidalaa

**Ebuka Umeokonkwo**
 [Github](https://github.com/ebukaume) | [Linkedin](https://www.linkedin.com/in/ebukaume) | [Slack](https://app.slack.com/team/UFDKXE68L) | [Twitter](https://twitter.com/ebukaume)