### PR TITLE
a relatively less restrictive Rubocop config

### DIFF
--- a/Ruby_less_restrictive/.rubocop.yml
+++ b/Ruby_less_restrictive/.rubocop.yml
@@ -1,0 +1,49 @@
+AllCops:
+  Exclude:
+    - "db/**/*"
+    - "bin/*" 
+    - "config/**/*"
+    - "Guardfile"
+    - "Rakefile"
+    - "README.md"
+
+  DisplayCopNames: true
+
+Metrics/LineLength:
+  Max: 120
+Metrics/MethodLength:
+  Include:
+    - "app/controllers/*"
+    - "app/models/*"
+  Max: 30
+Metrics/AbcSize:
+  Include:
+    - "app/controllers/*"
+    - "app/models/*"
+  Max: 50
+Metrics/ClassLength:
+  Max: 150
+Metrics/BlockLength:
+  ExcludedMethods: ['describe']
+  Max: 30
+
+Style/Documentation:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/EachForSimpleLoop:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/DefWithParentheses:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Layout/AlignHash:
+  EnforcedColonStyle: key
+Layout/ExtraSpacing:
+  AllowForAlignment: false
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented


### PR DESCRIPTION
Hello,

This PR results from a comment as described in this link `https://github.com/microverseinc/linters-config/issues/24` [screenshot below]

![Screen Shot 2019-11-26 at 6 45 38  #PM](https://user-images.githubusercontent.com/40712459/69658035-b7451080-107b-11ea-9459-26ccad31c1ba.png)

I made a comment just after that (when working on this issue) <-- see below

![Screen Shot 2019-11-26 at 6 48 17 PM](https://user-images.githubusercontent.com/40712459/69658121-e065a100-107b-11ea-8801-29d326fd392b.png)

### since same `.rubocop.yml` file is meant for RUBY+RAILS projects and that the `bin/` directory can be ignored for RAILS but not for Ruby, i recommend that for the RUBY project, this directory be renamed to ` "BINARIES" ` for future students

