### PR TITLE
Remove legacy layout cop from rubocop config file

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -25,8 +25,6 @@ Style/Documentation:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Layout/AlignHash:
-  EnforcedColonStyle: key
 Layout/ExtraSpacing:
   AllowForAlignment: false
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
I have removed the layout cop for the following reasons:

The following layout cop has been renamed to `Layout/HashAlignment` which is causing warnings when running Rubocop.
```yaml
Layout/AlignHash:
  EnforcedColonStyle: key
```
See Rubocop docs on [Layout/HashAlignment](https://docs.rubocop.org/en/latest/cops_layout/#layouthashalignment)
This cop can now be removed altogether as the default Rubocop setting for `Layout/HashAlignment` is now `EnforcedColonStyle: key`.