### PR TITLE
separating Ruby and ROR rubocop configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Each directory contains Stickler's config files specific to one programming lang
 
 - [css](./css)
 - [ruby](./ruby)
+- [Ruby on Rails](./ror)
 - [javascript](./javascript)
 - [react&redux](./react-redux)
 
@@ -59,6 +60,7 @@ In that case check detailed instructions for each linter:
 
 - [css](./css#troubleshooting)
 - [ruby](./ruby#troubleshooting)
+- [Ruby on Rails](./ror)
 - [javascript](./ruby#troubleshooting)
 - [react&redux](./react-redux#troubleshooting)
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In that case check detailed instructions for each linter:
 
 - [css](./css#troubleshooting)
 - [ruby](./ruby#troubleshooting)
-- [Ruby on Rails](./ror)
+- [Ruby on Rails](./ror#troubleshooting)
 - [javascript](./ruby#troubleshooting)
 - [react&redux](./react-redux#troubleshooting)
 

--- a/Ruby_less_restrictive/.rubocop.yml
+++ b/Ruby_less_restrictive/.rubocop.yml
@@ -1,0 +1,49 @@
+AllCops:
+  Exclude:
+    - "db/**/*"
+    - "bin/*" 
+    - "config/**/*"
+    - "Guardfile"
+    - "Rakefile"
+    - "README.md"
+
+  DisplayCopNames: true
+
+Metrics/LineLength:
+  Max: 120
+Metrics/MethodLength:
+  Include:
+    - "app/controllers/*"
+    - "app/models/*"
+  Max: 30
+Metrics/AbcSize:
+  Include:
+    - "app/controllers/*"
+    - "app/models/*"
+  Max: 50
+Metrics/ClassLength:
+  Max: 150
+Metrics/BlockLength:
+  ExcludedMethods: ['describe']
+  Max: 30
+
+Style/Documentation:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/EachForSimpleLoop:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/DefWithParentheses:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Layout/AlignHash:
+  EnforcedColonStyle: key
+Layout/ExtraSpacing:
+  AllowForAlignment: false
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented

--- a/ror/.rubocop.yml
+++ b/ror/.rubocop.yml
@@ -15,7 +15,7 @@ Metrics/MethodLength:
   Include:
     - "app/controllers/*"
     - "app/models/*"
-  Max: 30
+  Max: 20
 Metrics/AbcSize:
   Include:
     - "app/controllers/*"

--- a/ror/.stickler.yml
+++ b/ror/.stickler.yml
@@ -13,6 +13,7 @@ files:
     - "config/*"
     - "Guardfile"
     - "Rakefile"
+    - "README.md"
 
 # PLEASE DO NOT enable auto fixing options
 # if you need extra support from you linter - do it in your local env as described in README for this config

--- a/ror/.stickler.yml
+++ b/ror/.stickler.yml
@@ -8,6 +8,9 @@ linters:
 # add the files here you want to be ignored by stylelint
 files:
   ignore:
+    - "bin/*"
+    - "db/*"
+    - "config/*"
     - "Guardfile"
     - "Rakefile"
 

--- a/ror/README.md
+++ b/ror/README.md
@@ -1,0 +1,35 @@
+# Ruby Course & Ruby on Rails Course
+
+If you are not familiar with linters and Stickler, read [root level README](../README.md).
+
+Please do the following **steps in this order**:
+
+### Set-up Stickler (Github app) - it will show that your app is free from style errors
+1. Install stickler-ci https://github.com/apps/stickler-ci
+2. Enable stickler in your repo. You can do it [here](https://stickler-ci.com/).
+3. In first commit of your feature branch add a copy of [.stickler.yml](./.stickler.yml) and [.rubocop.yml](./.rubocop.yml)  to the root directory.
+    - **Remember** to use both files linked above
+    - **Remember** that `.stickler.yml` and `.rubocop.yml` file names start with a dot
+4. When you open your first pull request you should see Stickler's report at `Checks` tab.
+
+### Set-up Rubocop in your local env - it will help you to find style errors
+1. add `gem 'rubocop'` to `Gemfile` (not sure how to use Gemfile? Read [this](https://bundler.io/v1.15/guides/bundler_setup.html))
+2. run `bundle install`
+3. copy [.rubocop.yml](./.rubocop.yml) to the root directory of your project
+4. run `rubocop`
+5. fix linter errors
+6. **IMPORTANT NOTE**: feel free to research [auto-correct options for Rubocop](https://rubocop.readthedocs.io/en/latest/auto_correct/) if you get a flood of errors but keep in mind that correcting style errors manually will help you to make a habit of writing a clean code!
+
+
+## Troubleshooting
+
+1. All config files are in my repo bu Stickler does not work.
+    - Make sure that Stickler app has permission to access your repository. Find Stickler here https://github.com/settings/installations and check its configuration.
+    
+    ![screenshot](../assets/images/stickler_app_config.png)
+
+    - Try to add a new commit to your Pull Request. Stickler should detect changes in your repo and start checking your code.
+2. `while scanning for the next token found character '\t' that cannot start any token` error.
+    - Please make sure that you used spaces not tabs for indentation.
+3. Check if someone else has had similar problem before [here](https://questions.microverse.org/c/linters-stickler).
+4. Stickler does not work and nothing helps 💥 - run rubocop in your local env and correct all errors. **Remember to let your Code Reviewer know that you had problems with Stickler and you used linter in local env.**

--- a/ror/README.md
+++ b/ror/README.md
@@ -1,4 +1,4 @@
-# Ruby Course & Ruby on Rails Course
+# Ruby on Rails Course
 
 If you are not familiar with linters and Stickler, read [root level README](../README.md).
 

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,6 +1,8 @@
 AllCops:
   Exclude:
     - "README.md"
+    - "Guardfile"
+    - "Rakefile"
 
   DisplayCopNames: true
 

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,29 +1,33 @@
 AllCops:
   Exclude:
-    - "bin/*"
-    - "db/**/*"
-    - "config/**/*"
-    - "Guardfile"
-    - "Rakefile"
+    - "README.md"
+
   DisplayCopNames: true
 
 Metrics/LineLength:
   Max: 120
 Metrics/MethodLength:
-  Include: ["app/controllers/*"]
   Max: 20
 Metrics/AbcSize:
-  Include: ["app/controllers/*"]
-  Max: 30
+  Max: 50
 Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
   ExcludedMethods: ['describe']
+  Max: 30
 
 Style/Documentation:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false
+Style/EachForSimpleLoop:
+  Enabled: false
+Style/AndOr:
+  Enabled: false
+Style/DefWithParentheses:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
 
 Layout/AlignHash:
   EnforcedColonStyle: key

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,4 +1,4 @@
-# Ruby Course & Ruby on Rails Course
+# Ruby Course
 
 If you are not familiar with linters and Stickler, read [root level README](../README.md).
 


### PR DESCRIPTION

- created a `ror/` folder and copied `.rubocop.yml` config file i worked on few days ago which was a little less restrictive(or more friendly)
- also copied STICKLER from `ruby/` folder into `ror/` folder
- removed from `ruby/.rubocop.yml` file configs specific to RAILS projects
- crosschecked `ror/.rubocop.yml` file if there should be anything specific to ruby alone (it was OK)
- edited general README, to include links to Ruby & Rails folders
- edited heading of Ruby & Rails READMEs to have specific course-title