### PR TITLE
✨ Keep import/no-unresolved rule in the local Env

### DIFF
--- a/react-redux/.eslintrc.json
+++ b/react-redux/.eslintrc.json
@@ -15,7 +15,6 @@
   "plugins": ["react"],
   "rules": {
     "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
-    "import/no-unresolved": "off",
     "no-shadow": "off"
   }
 }

--- a/react-redux/.stickler.yml
+++ b/react-redux/.stickler.yml
@@ -3,6 +3,10 @@ linters:
   eslint:
     # indicate where is the config file for stylelint
     config: './.eslintrc.json'
+    # disable the import/no-unresolved rule from stickler only
+    rules: {
+      "import/no-unresolved": "off"
+    }
 
 # PLEASE DO NOT enable auto fixing options
 # if you need extra support from you linter - do it in your local env as described in README for this config

--- a/react-redux/.stickler.yml
+++ b/react-redux/.stickler.yml
@@ -2,11 +2,7 @@
 linters:
   eslint:
     # indicate where is the config file for stylelint
-    config: './.eslintrc.json'
-    # disable the import/no-unresolved rule from stickler only
-    rules: {
-      "import/no-unresolved": "off"
-    }
+    config: './.eslint.config'
 
 # PLEASE DO NOT enable auto fixing options
 # if you need extra support from you linter - do it in your local env as described in README for this config

--- a/react-redux/eslint.config
+++ b/react-redux/eslint.config
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    ".eslintrc.json"
+  ],
+  "rules": {
+    "import/no-unresolved": "off"
+  }
+}


### PR DESCRIPTION
### Keep import/no-unresolved rule in the local Environment
The "import/no-unresolved" rule is very useful for the developer experience in the local environment. However, Stickler environment seems to be missing most of the dependencies developers usually install locally, so this rule will always fail. to avoid that, the current configuration disables the rule in the eslintrc.json.

#### Problem
Eslint rule "import/no-unresolved" is needed locally and needs to be disabled on Stickler.

#### Solution
Move the disabling of "import/no-unresolved" from eslintrc.json to an extra custom rule in the stickler YAML file.