### PR TITLE
Change parser ecma version to 2018

### DIFF
--- a/javascript/eslint.config
+++ b/javascript/eslint.config
@@ -1,5 +1,5 @@
 {
-  "parserOptions": { "ecmaVersion": 6 },
+  "parserOptions": { "ecmaVersion": 2018 },
   "extends": "airbnb-base",
     rules: {
     'no-shadow': 0,


### PR DESCRIPTION
## Description of issue
* [ ] With the current config, stickler can not parse correctly features later than ES6 like `async...await` which is an important feature in the Javascript weather App. An example below is stickler not able to parse correctly the `async` syntax.
  ![image](https://user-images.githubusercontent.com/36057474/71534120-ce865080-28fc-11ea-84c5-9ef143601642.png) See https://github.com/bolah2009/js-testing-parserOptions/pull/1/commits/5b99a2da55e4239850fea54c74f183ba8685e970

* [ ] Browser specific methods may not work correctly with the current config with not `env` values defined. An example below is stickler not recognising the [Web Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
   ![image](https://user-images.githubusercontent.com/36057474/71534185-376dc880-28fd-11ea-87e7-5762b3973a49.png) See https://github.com/bolah2009/js-testing-parserOptions/commit/d6b99b9322f3b98f31f532238df07791cf256f40

## Proposed Solution

* [ ] The config file should be modified to support ES versions later than ES6
* [ ] `env` property and respective value should be added so that browser and jest specific methods/features will be recognized.

## Testing

I created two PR to test this config file. One with the old config: https://github.com/bolah2009/js-testing-parserOptions/pull/1 and other with the new config: https://github.com/bolah2009/js-testing-parserOptions/pull/2


@nidalaa 