### PR TITLE
Specify environments for predefined global variables

### DIFF
--- a/javascript/eslint.config
+++ b/javascript/eslint.config
@@ -1,4 +1,9 @@
 {
+  "env": {
+      "browser": true,
+      "es6": true,
+      "jest": true
+    },
   "parserOptions": { "ecmaVersion": 2018 },
   "extends": "airbnb-base",
     rules: {
@@ -6,5 +11,4 @@
     'no-param-reassign': 0,
     'eol-last': 0,
   }
-}
-
+} 


### PR DESCRIPTION
## Specify environments for predefined global variables

As a follow-up to this PR #31 this PR fixes the second issue raised in the previous PR:

> * [ ] Browser specific methods may not work correctly with the current config with not `env` values defined. An example below is stickler not recognising the [Web Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
   ![image](https://user-images.githubusercontent.com/36057474/71534185-376dc880-28fd-11ea-87e7-5762b3973a49.png) See https://github.com/bolah2009/js-testing-parserOptions/commit/d6b99b9322f3b98f31f532238df07791cf256f40

This PR adds `env` property and it's respective value so that browser, es6 and jest specific methods/features will be recognized.

``` json
 "env": {
      "browser": true,
      "es6": true,
      "jest": true
    }
```

Like in the react/redux config, the first property will support `browser`, `ES6` and  `jest` global variables.

More details here: https://eslint.org/docs/user-guide/configuring#specifying-environments