### PR TITLE
Solve The Metrics/Linelength error

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - "node_modules/**/*"
   DisplayCopNames: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 Metrics/MethodLength:
   Include: ["app/controllers/*"]

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -8,8 +8,6 @@ AllCops:
     - "node_modules/**/*"
   DisplayCopNames: true
 
-Layout/LineLength:
-  Max: 120
 Metrics/MethodLength:
   Include: ["app/controllers/*"]
   Max: 20


### PR DESCRIPTION
I was browsing to solve this issue because *stickler* was throwing an error and it was not possible to check the linting errors on vs code, It seems that property was changed for the most recent versions of *rubocop*, by implementing this change everything will work!!