### PR TITLE
Wrong Namespace: Rubocop

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - "Rakefile"
   DisplayCopNames: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 Metrics/MethodLength:
   Include: ["app/controllers/*"]


### PR DESCRIPTION
updated the name from Metrics/LineLength to Layout/LineLength

Please, I would really appreciate it if my pull request is merged. I'm so excited to find this out.