### PR TITLE
Change obsolete Rubocop namespace for Linelength cop

### DIFF
--- a/ror/.rubocop.yml
+++ b/ror/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
 
   DisplayCopNames: true
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 Metrics/MethodLength:
   Include:


### PR DESCRIPTION
Rubocop namespace as introduced here this change was introduced here https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#changes-2.


`Metrics/LineLength` is `Layout/LineLength` now.