### PR TITLE
Changes to the rules to be consistent with stickler errors.

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -12,6 +12,7 @@
   "rules": {
     "no-shadow": "off",
     "no-param-reassign": "off",
-    "eol-last": "off"
+    "eol-last": "off",
+    "arrow-parens": "off"
   }
 }

--- a/react-redux/.eslintrc.json
+++ b/react-redux/.eslintrc.json
@@ -16,6 +16,7 @@
   "rules": {
     "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
     "import/no-unresolved": "off",
-    "no-shadow": "off"
+    "no-shadow": "off",
+    "arrow-parens":"off"
   }
 }

--- a/react-redux/README.md
+++ b/react-redux/README.md
@@ -19,7 +19,23 @@ Please do the following **steps in this order**:
 2. Run `npx eslint --init`.
 3. Make sure you select the following options when prompted.
 
-![screenshot](../assets/images/eslint_config.PNG)
+    `? How would you like to use ESLint?` To check syntax, find problems, and enforce code style
+
+    `? What type of modules does your project use?` JavaScript modules (import/export)
+
+    `? Which framework does your project use?`  React
+
+    `? Does your project use Typescript`  No
+
+    `? Where does your code run?`     Browser
+
+    `? How would you like to define a style for your project?` Use a popular style guide
+
+    `? Which style guide do you want to follow?`      Airbnb
+
+    `? What format do you want your config file to be in?`       JSON
+
+    `The config that you've selected requires the following dependencies: ? Would you like to install them now with npm?`       Yes
 
 4. Copy the contents of [.eslintrc.json](./.eslintrc.json) to the newly generated `.eslintrc.json` overwritting the previous content.
 5. **Do not make any changes in config files - they represent style guidelines that you share with your tem - which is a group of all Microverse students.**


### PR DESCRIPTION
## This PR creates a hotfix for the current errors being brought up in the Full-time students challenge.

- They consist of the following, the error that was brought to us was that the stickler check was bringing an error related to the arrow-parens rule which states, according to the documentation, that even if there is only one parameter being passed in an arrow function it does require for it to be enclosed in parens. But the stickler check thinks otherwise, and since there is no way to bypass this error, the only solution would be to turn off the arrow-parens rule in the local environment so that we can have a consistent linting in all stages of development.

- The change proposed for the react section follows along with the same principles. And there is also a change in the README file to be more consistent with the Javascript section one.