### PR TITLE
Turn "on" arrow-parens rule to enforce style

### DIFF
--- a/react-redux/.eslintrc.json
+++ b/react-redux/.eslintrc.json
@@ -17,6 +17,6 @@
     "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
     "import/no-unresolved": "off",
     "no-shadow": "off",
-    "arrow-parens":"off"
+    "arrow-parens": ["error", "as-needed"]
   }
 }


### PR DESCRIPTION
### Turn ``arrow-parens`` rule "On" to enforce style.

By setting **"arrow-paren"s** to **"Off"** some **"ugly"** code can skip through a developer's eye.

**Airbnb** standard [here](https://github.com/airbnb/javascript#arrow-functions) thinks it's a good idea to set **"arrow-parens"** to **"always"**, to enforce the use of parenthesis around argument (single or multiple).

On the other hand, **Eslint** [here](https://eslint.org/docs/rules/arrow-parens#further-reading) was inspired by **Airbnb** to add support for **"arrow-parens"** set to **"as-needed"**. This update will also enable code formatters like **Prettier** to automagically include parenthesis on multiple arguments, and remove them from single arguments.

In this PR, I suggest, to set **"arrow-parens"** to **"as-needed"**, rather than **"Off"** to enforce style, encourage the developer to write cleaner codes, and catch any code slip.

An issue was raised [here](https://github.com/eslint/eslint/issues/8682) for this modification affecting **"async"**, however, it has been resolved.

This PR came as a result of several discussions and research with a TSE (@bolah2009), who provided insight on this [PR](https://github.com/johnsonsirv/redux-bookstore/pull/1).

Thanks