### PR TITLE
Added extra line on the README for the JS linter config

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -28,7 +28,7 @@ Please do the following **steps in this order**:
 
    - Not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)..
 
-   - Once you have everything setup and **BEFORE YOU MOVE TO THE NEXT STEP**, if you haven't run the following command from your terminal: `npm init -y`.
+   - Once you have everything setup and **BEFORE YOU MOVE TO THE NEXT STEP**, if you haven't, run the following command from your terminal: `npm init -y`.
 
 2) Run `npx eslint --init`.
 3) Make sure you select the following options when prompted.

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -5,55 +5,59 @@ If you are not familiar with linters and Stickler, read [root level README](../R
 Please do the following **steps in this order**:
 
 ### Set-up Stickler (Github app) - it will show that your app is free from style errors
+
 1. Install stickler-ci https://github.com/apps/stickler-ci
 2. Enable stickler in your repo. You can do it [here](https://stickler-ci.com/).
 3. In first commit of your feature branch add a copy of [.stickler.yml](./.stickler.yml).
    - **Remember** to use the file linked above
    - **Remember** that `.stickler.yml` file name starts with a dot.
 4. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**
-    - If you think that a change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
+   - If you think that a change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
 5. When you first open a pull request you should see Stickler's report at `Checks` tab.
 
 ### Set-up ESlint in your local env - it will help you to find style errors
-1. Make sure you have `Nodejs` and `npm` installed locally on your computer by running `node -v` and `npm -v` on your terminal, you should see an output that looks like this: 
 
-    `node -v v13.6.8`
+1. Make sure you have `Nodejs` and `npm` installed locally on your computer by running `node -v` and `npm -v` on your terminal, you should see an output that looks like this:
 
-    `npm -v 6.13.4`
+   - `node -v v13.6.8`
 
-    If you don't have Nodejs installed on your computer, here is a [great article on how to do it.](https://linuxize.com/post/how-to-install-node-js-on-ubuntu-18.04/) (for ubuntu users). 
-    For Mac and Windows users visit [the official Nodejs website to download the installation files](nodejs.org).
+   - `npm -v 6.13.4`
 
-    Not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+   - If you don't have Nodejs installed on your computer, here is a [great article on how to do it.](https://linuxize.com/post/how-to-install-node-js-on-ubuntu-18.04/) (for ubuntu users).
+     For Mac and Windows users visit [the official Nodejs website to download the installation files](nodejs.org).
 
-2. Run `npx eslint --init`.
-3. Make sure you select the following options when prompted.
+   - Not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)..
 
-    `? How would you like to use ESLint?` To check syntax, find problems, and enforce code style
+   - Once you have everything setup and **BEFORE YOU MOVE TO THE NEXT STEP**, if you haven't run the following command from your terminal: `npm init -y`.
 
-    `? What type of modules does your project use?` JavaScript modules (import/export)
+2) Run `npx eslint --init`.
+3) Make sure you select the following options when prompted.
 
-    `? Which framework does your project use?`  None of these
+   `? How would you like to use ESLint?` To check syntax, find problems, and enforce code style
 
-    `? Does your project use Typescript`  No
+   `? What type of modules does your project use?` JavaScript modules (import/export)
 
-    `? Where does your code run?`     Browser
+   `? Which framework does your project use?` None of these
 
-    `? How would you like to define a style for your project?` Use a popular style guide
+   `? Does your project use Typescript` No
 
-    `? Which style guide do you want to follow?`      Airbnb
+   `? Where does your code run?` Browser
 
-    `? What format do you want your config file to be in?`       JSON
+   `? How would you like to define a style for your project?` Use a popular style guide
 
-    `The config that you've selected requires the following dependencies: ? Would you like to install them now with npm?`       Yes
+   `? Which style guide do you want to follow?` Airbnb
 
-4. Copy the contents of [.eslintrc.json](./.eslintrc.json) to the newly generated `.eslintrc.json` overwritting the previous content, this will remove the globals ruleset, add a new enviroment and add some custom rules.
-5. **Do not make any changes in config files - they represent style guidelines that you share with your tem - which is a group of all Microverse students.**
-    - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
-5. Double check your `./src` folder for any extra unnecesary `.eslint` config files that might have been generated as this might cause an issue with stickler when you create your Pull Request later on.
-6. Run `npx eslint .`.
-7. Fix linter errors.
-8. **IMPORTANT NOTE**: feel free to research [auto-correct options for ESlint](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) if you get a flood of errors but keep in mind that correcting style errors manually will help you to make a habit of writing a clean code!
+   `? What format do you want your config file to be in?` JSON
+
+   `The config that you've selected requires the following dependencies: ? Would you like to install them now with npm?` Yes
+
+4) Copy the contents of [.eslintrc.json](./.eslintrc.json) to the newly generated `.eslintrc.json` overwritting the previous content, this will remove the globals ruleset, add a new enviroment and add some custom rules.
+5) **Do not make any changes in config files - they represent style guidelines that you share with your tem - which is a group of all Microverse students.**
+   - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
+6) Double check your `./src` folder for any extra unnecesary `.eslint` config files that might have been generated as this might cause an issue with stickler when you create your Pull Request later on.
+7) Run `npx eslint .`.
+8) Fix linter errors.
+9) **IMPORTANT NOTE**: feel free to research [auto-correct options for ESlint](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) if you get a flood of errors but keep in mind that correcting style errors manually will help you to make a habit of writing a clean code!
 
 ## Troubleshooting
 


### PR DESCRIPTION
## This Pull Request attempts to improve the configuration of the linter, specifically for the first and second Javascript projects.

- The issue is the following: 
   - The Library Project and the Tic Tac Toe project, explore concepts in the spectrum of programing paradigms, factory functions, module pattern, objects, and constructors, in these projects we are not using webpack yet, which means the active use of node package modules is not yet introduced. I've made a couple of reviews for those projects where the `package.json` file was not present at all, meaning that running `npx eslint --init` and `npx eslint .` will not provide the proper functionality for linting in the IDE, neither will it make stickler behavior predictable.

So I added a couple of lines to fix this:

## From this: 
![image](https://user-images.githubusercontent.com/46115725/72841339-c69ba100-3c5b-11ea-804a-3c9d625eeb7c.png)

## To this: 
![image](https://user-images.githubusercontent.com/46115725/72841540-34e06380-3c5c-11ea-9356-3cdd46836487.png)

This will avoid confusion from newcomers to the Javascript section.