### PR TITLE
Bash script to compare linters files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Follow those instructions in order to set up linters or validators in your repo.
 
 In order to get to know more about linters and Stickler read the recap below.
 
-
 ## Linters
 
 A linter is a tool that analyzes your source code to flag programming errors, bugs, stylistic errors, and suspicious constructs(source: [Wikipedia](<https://en.wikipedia.org/wiki/Lint_(software)>)).
@@ -64,6 +63,12 @@ In that case check detailed instructions for each linter:
 - [ror](./ror#troubleshooting)
 - [javascript](./javascript#troubleshooting)
 - [react&redux](./react-redux#troubleshooting)
+
+## Validation
+
+Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.
+
+TSEs will validate that you are using the same configuration files provided here. You can check if your linter configuration is correct using the [`check-linters-config`](scripts) script.
 
 ## Contributing
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,35 @@
+# check-linters-confg
+
+`check-linters-config` is a Bash script to compare local files against the files on the master branch of this repository. It will check that files exist and that they are **identical** to the ones here.
+
+## Installation
+
+1. Copy the [`check-linters-conf.sh`](check-linters-conf.sh) file into someplace in the `$PATH` of your machine, for example `/usr/local/bin`:
+
+```
+sudo wget -O /usr/local/bin/check-linters-config https://raw.githubusercontent.com/microverseinc/linters-config/master/scripts/check-linters-conf.sh
+```
+
+2. Make it executable:
+
+```
+sudo chmod +x /usr/local/bin/check-linters-config
+```
+
+## Usage
+
+Run the command `check-linters-config` on the root of the repository you want to check. It takes as an argument the name of the directory you want to check against.
+
+```
+$ check-linters-config ruby
+Files master/ruby/.stickler.yml and .stickler.yml differ
+Files master/ruby/.rubocop.yml and .rubocop.yml are identical
+```
+
+The possible directories/options included are:
+
+- [css](https://github.com/microverseinc/linters-config/tree/master/css)
+- [javascript](https://github.com/microverseinc/linters-config/tree/master/javascript)
+- [react-redux](https://github.com/microverseinc/linters-config/tree/master/react-redux)
+- [ror](https://github.com/microverseinc/linters-config/tree/master/ror)
+- [ruby](https://github.com/microverseinc/linters-config/tree/master/ruby)

--- a/scripts/check-linters-conf.sh
+++ b/scripts/check-linters-conf.sh
@@ -46,7 +46,7 @@ case $1 in
   config_files=(".stickler.yml" ".rubocop.yml")
   ;;
   javascript | react-redux)
-  config_files=(".stickler.yml" ".eslint.json")
+  config_files=(".stickler.yml" ".eslintrc.json")
   ;;
   *)
   echo "$usage"

--- a/scripts/check-linters-conf.sh
+++ b/scripts/check-linters-conf.sh
@@ -1,0 +1,56 @@
+#/bin/bash
+
+base_url="https://raw.githubusercontent.com/microverseinc/linters-config"
+branch="master"
+usage="
+Usage: check-linters-config dir
+
+Please provide a valid dir to compare againts.
+
+Valid options for dir:
+  css
+  javascript
+  react-redux
+  ror
+  ruby
+
+Example: check-linters-config ruby
+"
+
+compare () {
+  directory="$1"
+  config_files="$2"
+  for file in "${config_files[@]}"; do
+    if [ -f "${file}" ]; then
+      original_file="${branch}/${directory}/${file}"
+      wget -qO- "${base_url}/${original_file}" |
+      diff \
+        --brief \
+        --report-identical-files \
+        --ignore-all-space \
+        --ignore-blank-lines \
+        --strip-trailing-cr \
+        --label="${original_file}" \
+        - "${file}"
+    else
+      echo "File '${file}' is missing"
+    fi
+  done
+}
+
+case $1 in
+  css)
+  config_files=(".stickler.yml" "stylelint.config.js")
+  ;;
+  ruby | ror)
+  config_files=(".stickler.yml" ".rubocop.yml")
+  ;;
+  javascript | react-redux)
+  config_files=(".stickler.yml" ".eslint.json")
+  ;;
+  *)
+  echo "$usage"
+  exit 1
+esac
+
+compare "$1" "${config_files[@]}"


### PR DESCRIPTION
# check-linters-confg

`check-linters-config` is a bash script to compare local files against the files on the master branch of this repository. It will Check that files exist and that they are identical to the ones here.

## Installation

1. Copy the [`check-linters-conf.sh`](check-linters-conf.sh) file into someplace in the `$PATH` of your machine, for example `/usr/local/bin`:

```sh
sudo wget -O /usr/local/bin/check-linters-config https://raw.githubusercontent.com/MauricioRobayo/linters-config/feature/verification-script/scripts/check-linters-conf.sh
```

2. Make it executable:

```
sudo chmod +x /usr/local/bin/check-linters-config
```

## Usage

Run the command `check-linters-config` on the root of the repository you want to check. It takes as an argument the name of the directory you want to check against.

```sh
$ check-linters-config ruby
Files master/ruby/.stickler.yml and .stickler.yml differ
Files master/ruby/.rubocop.yml and .rubocop.yml are identical
```

The possible directories/options included are:

- [css](https://github.com/microverseinc/linters-config/tree/master/css)
- [javascript](https://github.com/microverseinc/linters-config/tree/master/javascript)
- [react-redux](https://github.com/microverseinc/linters-config/tree/master/react-redux)
- [ror](https://github.com/microverseinc/linters-config/tree/master/ror)
- [ruby](https://github.com/microverseinc/linters-config/tree/master/ruby)
