### PR TITLE
[Update] Updated linter check to allow ternary nesting

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -13,6 +13,7 @@
     "no-shadow": "off",
     "no-param-reassign": "off",
     "eol-last": "off",
-    "arrow-parens": "off"
+    "arrow-parens": "off",
+    "no-nested-ternary" : "off"
   }
 }


### PR DESCRIPTION
Changed the linter config to allow ternary rule nesting on JS based on this articles:

https://medium.com/javascript-scene/nested-ternaries-are-great-361bddd0f340
https://hackernoon.com/the-untapped-potential-of-nested-ternaries-2cb98079b634

