### PR TITLE
Fixed errors due to rubocop 0.81 update

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -5,7 +5,8 @@ AllCops:
     - "Rakefile"
 
   DisplayCopNames: true
-
+  DisabledByDefault: true
+  
 Layout/LineLength:
   Max: 120
 Metrics/MethodLength:
@@ -39,3 +40,15 @@ Layout/ExtraSpacing:
 Layout/MultilineMethodCallIndentation:
   Enabled: true
   EnforcedStyle: indented
+
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true


### PR DESCRIPTION
The new version of Rubocop requires new cops to be explicitly set to true or false. 

![image](https://user-images.githubusercontent.com/34813339/78646479-62cb6080-78b9-11ea-8bc2-222d8fe90eb2.png)


Many students are having trouble due to [stickler](https://stickler-ci.com/docs#ruby) having updated their Rubocop version to 0.81.

I propose one or both changes: Setting all cops to "DisabledByDefault: true", and/or setting the highlighted new cops above to true or false (I have made them true in this file)