### PR TITLE
add `reset.css` to ignored files

### DIFF
--- a/css/.stickler.yml
+++ b/css/.stickler.yml
@@ -3,6 +3,11 @@ linters:
   stylelint:
     # indicate where is the config file for stylelint
     config: 'stylelint.config.js'
+# students using a reset css is very common, and forcing them to have a css folder
+# is a good practice
+files:
+  ignore:
+    - 'css/reset.css'
 
 # PLEASE DO NOT enable auto fixing options
 # if you need extra support from you linter - do it in your local env as described in README for this config


### PR DESCRIPTION
It would be nice if we avoid situations where students have to modify the stickler configuration file just to ignore the reset file they got from somewhere on the Internet, and as an added benefit, they'll be forced to have a `css/` folder where they should place all of their stylesheets.