### PR TITLE
Updated ror Readme with the info to resolve the stylelint error for API only Rails app(#83)

### DIFF
--- a/ror/README.md
+++ b/ror/README.md
@@ -79,3 +79,8 @@ Make sure that you do not modify the [`.github/workflows/linters.yml`](.github/w
 - [Deploying to Heroku from GitHub Actions](https://dev.to/heroku/deploying-to-heroku-from-github-actions-29ej)
 - [Building a Rails CI pipeline with GitHub Actions](https://boringrails.com/articles/building-a-rails-ci-pipeline-with-github-actions/)
 - [Github Actions to run Rubocop and RSpec tests on Rails with Postgres](https://dev.to/abdellani/github-actions-to-run-rubocop-and-rspec-tests-on-rails-with-postgres-47i)
+
+## Troubleshooting
+
+- If you are building an API only Rails application
+For API only Rails application you can remove the Stylelint config. To do so remove line no. [23](https://github.com/microverseinc/linters-config/blob/f0c812753d0418288c404ed4a441a2e7370e9f4e/ror/.github/workflows/linters.yml#L23) to [36](https://github.com/microverseinc/linters-config/blob/f0c812753d0418288c404ed4a441a2e7370e9f4e/ror/.github/workflows/linters.yml#L36) from the [linter.yml]((https://github.com/microverseinc/linters-config/blob/master/ror/.github/workflows/linters.yml)) file.


### PR DESCRIPTION
### PR contains the following updates to solve the issues (#83)
- Added a troubleshoot section.
- Added instructions to remove the Stylelint config from the [linter.yml](https://github.com/microverseinc/linters-config/blob/master/ror/.github/workflows/linters.yml) file