### PR TITLE
remove reference to stickler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # linters-config
 
-This is the **GitHub Actions configuration**. If you are looking for the **Stickler configuration**, you can find it [here](https://github.com/microverseinc/linters-config/tree/Stickler).
+## GitHub Actions configuration
 
 ## How to use this repo? 🤔
 

--- a/html-css/README.md
+++ b/html-css/README.md
@@ -1,6 +1,6 @@
 # HTML & CSS3 Course
 
-This is the **GitHub Actions configuration**. If you are looking for the **Stickler configuration**, you can find it [here](https://github.com/microverseinc/linters-config/tree/Stickler/css).
+## GitHub Actions configuration
 
 If you are not familiar with linters, read [root level README](../README.md).
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,6 +1,6 @@
 # JavaScript
 
-This is the **GitHub Actions configuration**. If you are looking for the **Stickler configuration**, you can find it [here](https://github.com/microverseinc/linters-config/tree/Stickler/javascript).
+## GitHub Actions configuration
 
 If you are not familiar with linters and GitHub Actions, read [root level README](../README.md).
 

--- a/react-redux/README.md
+++ b/react-redux/README.md
@@ -1,6 +1,6 @@
 # React and Redux
 
-This is the **GitHub Actions configuration**. If you are looking for the **Stickler configuration**, you can find it [here](https://github.com/microverseinc/linters-config/tree/Stickler/react-redux).
+## GitHub Actions configuration
 
 If you are not familiar with linters and GitHub Actions, read [root level README](../README.md).
 

--- a/ror/README.md
+++ b/ror/README.md
@@ -1,7 +1,6 @@
 # Ruby on Rails Course
 
-This is the **GitHub Actions configuration**. If you are looking for the **Stickler configuration**, you can find it [here](https://github.com/microverseinc/linters-config/tree/Stickler/ror).
-
+## GitHub Actions configuration
 
 If you are not familiar with linters and GitHub Actions, read [root level README](../README.md).
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,6 +1,6 @@
 # Ruby Course
 
-This is the **GitHub Actions configuration**. If you are looking for the **Stickler configuration**, you can find it [here](https://github.com/microverseinc/linters-config/tree/Stickler/ruby).
+## GitHub Actions configuration
 
 If you are not familiar with linters and GitHub Actions, read [root level README](../README.md).
 


### PR DESCRIPTION
The intent of the pull request is to remove the reference to the former linter configuration(stickler) as it is almost 2 months since the switch and I still see students using it, the reference on there makes it look like stickler is an option, so I believe removing it now is the best way to emphasis that it isn't and everyone should use GitHub actions.