### PR TITLE
Disabled react/react-in-jsx-scope

### DIFF
--- a/react-redux/.eslintrc.json
+++ b/react-redux/.eslintrc.json
@@ -16,6 +16,7 @@
   "plugins": ["react"],
   "rules": {
     "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
+    "react/react-in-jsx-scope": "off",
     "import/no-unresolved": "off",
     "no-shadow": "off",
     "arrow-parens": ["error", "as-needed"]


### PR DESCRIPTION
react/react-in-jsx-scope should be disabled since react doesn't need 
```javascript
import React from 'react'
```
 anymore in components made with functions.
I think it's better to let the student decide to add it or not, and in places where it's supposed to be added (component classes) React wouldn't work without it so they'll need to add it anyway, so I think this rule is useless.