### PR TITLE
Remove --deployment flag from ruby related config

### DIFF
--- a/ruby/.github/workflows/tests.yml
+++ b/ruby/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
           ruby-version: 2.6.x
       - name: Setup RSpec
         run: |
+          gem install bundler
           [ -f Gemfile ] && bundle --deployment
           gem install --no-document rspec:'~>3.0'
       - name: RSpec Report

--- a/ruby/.github/workflows/tests.yml
+++ b/ruby/.github/workflows/tests.yml
@@ -13,8 +13,7 @@ jobs:
           ruby-version: 2.6.x
       - name: Setup RSpec
         run: |
-          gem install bundler
-          [ -f Gemfile ] && bundle --deployment
+          [ -f Gemfile ] && bundle
           gem install --no-document rspec:'~>3.0'
       - name: RSpec Report
         run: rspec --force-color --format documentation


### PR DESCRIPTION
This PR removes the deprecated --deployment flag from ruby and rails related config:
- This will help suppress the deprecation warnings from bundler, more [here](https://github.com/rubygems/bundler/blob/d4993be66fa2e76b3ca00ea56a51ecab5478b726/UPGRADING.md#bundler-3)
- This would not prevent errors when the user does not commit `Gemfile.lock` file
   ```
   The --deployment flag requires a Gemfile.lock. Please make sure you have checked 
   your Gemfile.lock into version control before deploying.
   ```