### PR TITLE
Update instructions to use Yarn instead of npm

### DIFF
--- a/react-redux/README.md
+++ b/react-redux/README.md
@@ -29,11 +29,11 @@ Click on the `Details` link to see the full output and the errors that need to b
 
 ### ESLint
 
-1. Run `npm install --save-dev eslint@6.8.x eslint-config-airbnb@18.1.x eslint-plugin-import@2.20.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@2.5.x babel-eslint@10.1.x` (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
+1. Run `yarn add eslint@6.8.x eslint-config-airbnb@18.1.x eslint-plugin-import@2.20.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@2.5.x babel-eslint@10.1.x --dev` (not sure how to use yarn? Read [this](https://yarnpkg.com/getting-started/install)).
 2. Copy [.eslintrc.json](./.eslintrc.json) to the root directory of your project.
 3. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**
     - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
-4. Run `npx eslint .` on the root of your directory of your project.
+4. Run `yarn eslint .` on the root of your directory of your project.
 5. Fix linter errors.
 6. **IMPORTANT NOTE**: feel free to research [auto-correct options for Stylelint](https://stylelint.io/user-guide/cli#autofixing-errors) if you get a flood of errors but keep in mind that correcting style errors manually will help you to make a habit of writing a clean code!
 
@@ -42,17 +42,17 @@ Click on the `Details` link to see the full output and the errors that need to b
 1. Run
 
    ```
-   npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+   yarn add stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator --dev
    ```
 
-   (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
+   (not sure how to use yarn? Read [this](https://yarnpkg.com/getting-started/install)).
 
 2. Copy [.stylelintrc.json](./.stylelintrc.json) to the root directory of your project.
 3. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**
    - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
 4. Run
    ```
-   npx stylelint "**/*.{css,scss}"
+   yarn stylelint "**/*.{css,scss}"
    ```
    on the root of your directory of your project.
 5. Fix linter errors.


### PR DESCRIPTION
when using `npx create-react-app` it will install everything in yarn, and create a `yarn.lock` file, then when you use these instructions, you'd use npm, which creates `package-lock.json`, it is not recommended to use both at the same time, and Heroku would tell you to remove one as you can see in the image below:

![image](https://user-images.githubusercontent.com/11758151/100004233-80f1bc80-2dc7-11eb-84d4-1f5df49b96e1.png)

so since react would force us to use yarn, I've changed the instructions here to use it instead of npm, so that way students wouldn't face this problem or get confused which to keep.
