### PR TITLE
Update containers and ruby version

### DIFF
--- a/ror/.github/workflows/linters.yml
+++ b/ror/.github/workflows/linters.yml
@@ -8,21 +8,21 @@ env:
 jobs:
   rubocop:
     name: Rubocop
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 3.0.x
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'~>0.81.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop:'~>1.9' # https://docs.rubocop.org/en/stable/installation/
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ror/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color
   stylelint:
     name: Stylelint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/ruby/.github/workflows/linters.yml
+++ b/ruby/.github/workflows/linters.yml
@@ -5,15 +5,15 @@ on: pull_request
 jobs:
   rubocop:
     name: Rubocop
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 3.0.x
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'~>0.81.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop:'~>1.9' # https://docs.rubocop.org/en/stable/installation/
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ruby/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color

--- a/ruby/.github/workflows/tests.yml
+++ b/ruby/.github/workflows/tests.yml
@@ -5,15 +5,15 @@ on: pull_request
 jobs:
   rspec:
     name: RSpec
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 3.0.x
       - name: Setup RSpec
         run: |
           [ -f Gemfile ] && bundle
-          gem install --no-document rspec:'~>3.0'
+          gem install --no-document rspec:'~>3.10'
       - name: RSpec Report
         run: rspec --force-color --format documentation


### PR DESCRIPTION
The old version old Rubocop doesn't support the latest version of ruby. This pull request updates the container version to the latest version of Ubuntu LTS, ruby, and Rubocop. (Solves  issue #123)

![Error](https://user-images.githubusercontent.com/1642014/106616445-9f6df400-657e-11eb-93bd-62815affefe4.png)

I tested this new configuration with my [ror-social-scaffold](https://github.com/sinansevgi/ror-social-scaffold/pull/10/checks?check_run_id=1831889675), [tic-tac-toe](https://github.com/sinansevgi/Tic-Tac-Toe/pull/2/checks?check_run_id=1831936494) and my [capstone project](https://github.com/sinansevgi/programming_articles/runs/1831372924?check_suite_focus=true)
