### PR TITLE
Update linters yml for ruby with latest rubocop

### DIFF
--- a/ruby/.github/workflows/linters.yml
+++ b/ruby/.github/workflows/linters.yml
@@ -6,14 +6,15 @@ jobs:
   rubocop:
     name: Rubocop
     runs-on: ubuntu-18.04
+    
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: ">=2.6.x"
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'~>0.81.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop:'~>1.9.0' # https://docs.rubocop.org/en/stable/installation/
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ruby/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: enable
   Exclude:
     - "Guardfile"
     - "Rakefile"
@@ -14,7 +15,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
-  ExcludedMethods: ['describe']
+  IgnoredMethods: ['describe']
   Max: 30
 
 


### PR DESCRIPTION
This change at the linters.yml for ruby projects fix the linters not working on ruby 3.0.X.

It works on any ruby version equal or higher than Ruby 2.6.X