### PR TITLE
Update linter's workflow for Ruby on Rails

### DIFF
--- a/ror/.github/workflows/linters.yml
+++ b/ror/.github/workflows/linters.yml
@@ -8,29 +8,29 @@ env:
 jobs:
   rubocop:
     name: Rubocop
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: ">=2.7.x"
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'~>0.81.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop # https://docs.rubocop.org/en/stable
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ror/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color
   stylelint:
     name: Stylelint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: ">=15.x"
       - name: Setup Stylelint
         run: |
-          npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+          npm install --save-dev stylelint stylelint-scss stylelint-config-standard stylelint-csstree-validator
           [ -f .stylelintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ror/.stylelintrc.json
       - name: Stylelint Report
         run: npx stylelint "**/*.{css,scss}"

--- a/ror/.rubocop.yml
+++ b/ror/.rubocop.yml
@@ -1,16 +1,14 @@
 AllCops:
   Exclude:
     - "db/**/*"
-    - "bin/*" 
+    - "bin/*"
     - "config/**/*"
     - "Guardfile"
     - "Rakefile"
     - "node_modules/**/*"
-
   DisplayCopNames: true
+  NewCops: enable
 
-Layout/LineLength:
-  Max: 120
 Metrics/MethodLength:
   Include:
     - "app/controllers/*"
@@ -24,7 +22,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
-  ExcludedMethods: ['describe']
+  IgnoredMethods: ['describe']
   Max: 30
 
 Style/Documentation:
@@ -39,7 +37,15 @@ Style/DefWithParentheses:
   Enabled: false
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never
+Style/HashEachMethods:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
+  Enabled: false
 
+Layout/LineLength:
+  Max: 120
 Layout/HashAlignment:
   EnforcedColonStyle: key
 Layout/ExtraSpacing:
@@ -47,13 +53,8 @@ Layout/ExtraSpacing:
 Layout/MultilineMethodCallIndentation:
   Enabled: true
   EnforcedStyle: indented
+
 Lint/RaiseException:
   Enabled: false
 Lint/StructNewOverride:
-  Enabled: false
-Style/HashEachMethods:
-  Enabled: false
-Style/HashTransformKeys:
-  Enabled: false
-Style/HashTransformValues:
   Enabled: false


### PR DESCRIPTION
# Using the latest linter's version by default

The official recommendation is to use the latest stable version of the linters for new projects. Since this repository is mainly used for new projects, it should stick to the recommendation.

By removing the explicit version from the workflow, new projects based on this repository will use the linter's latest version by default. This helps to:
  1. Remove the discrepancy between the development machine using a newer version and the workflow using an older version.
  2. Avoid the need to constantly updating this file to change the linter's version.
  3. Stick to the recommendation by using the latest stable version by default for new projects.

As a proof of concept, please check the following demonstration pull request using the proposed changes contained in this pull request: https://github.com/NoTengoBattery/installing-rails/pull/1.

Any comments are welcome. If you have any problem with this code, discuss it in this pull request. For code in the master/main branch, please open a GitHub Issue [here](https://github.com/notengobattery/linters-config/issues).