### PR TITLE
Fix Eslint Installation Command In React README

### DIFF
--- a/react-redux/README.md
+++ b/react-redux/README.md
@@ -29,7 +29,7 @@ Click on the `Details` link to see the full output and the errors that need to b
 
 ### ESLint
 
-1. Run `npm install --save-dev eslint@7.11.x eslint-config-airbnb@18.1.x eslint-plugin-import@2.22.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@2.5.x babel-eslint@10.1.x` (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
+1. Run `npm install --save-dev eslint@7.11.x eslint-config-airbnb@18.1.x eslint-plugin-import@2.22.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@2.5.x babel-eslint@10.1.x --legacy-peer-deps` (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
 2. Copy [.eslintrc.json](./.eslintrc.json) to the root directory of your project.
 3. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**
     - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.


### PR DESCRIPTION
# Issue

Running `npm install --save-dev eslint@7.11.x eslint-config-airbnb@18.1.x eslint-plugin-import@2.22.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@2.5.x babel-eslint@10.1.x` using npm 7.x causes the following error, even though it works perfectly with npm 6.x.

![error](https://user-images.githubusercontent.com/22526062/107854389-842ba000-6e2c-11eb-8d9d-e06085ed4602.png)

# Fix

Adding the --legacy-peer-deps flag makes it work like in npm 6.x.

Similar issues:
https://github.com/npm/cli/issues/2615
https://github.com/angular/angular-cli/issues/19957

Explanation:
https://github.blog/2021-02-02-npm-7-is-now-generally-available/#peer-dependencies