### PR TITLE
Exclude node_modules folder

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   Exclude:
     - "Guardfile"
     - "Rakefile"
+    - "node_modules/**/*"
 
   DisplayCopNames: true
 


### PR DESCRIPTION
I added a line to exclude the node_modules folder since it's been messing with it to some students.

more [here](https://microverse-students.slack.com/archives/GA812K2TC/p1615310273054200)