### PR TITLE
Add "inline-style-disabled" Hint

### DIFF
--- a/html-css/.hintrc
+++ b/html-css/.hintrc
@@ -13,6 +13,6 @@
     "html-checker",
     "meta-charset-utf-8",
     "meta-viewport",
-    "no-inline-styles"
+    "no-inline-styles:error"
   ]
 }

--- a/html-css/.hintrc
+++ b/html-css/.hintrc
@@ -12,6 +12,7 @@
     "disown-opener",
     "html-checker",
     "meta-charset-utf-8",
-    "meta-viewport"
+    "meta-viewport",
+    "inline-style-disabled"
   ]
 }

--- a/html-css/.hintrc
+++ b/html-css/.hintrc
@@ -13,6 +13,6 @@
     "html-checker",
     "meta-charset-utf-8",
     "meta-viewport",
-    "inline-style-disabled"
+    "no-inline-styles"
   ]
 }


### PR DESCRIPTION
I've added the `inline-style-disabled` hint so students will no longer use stylings on the HTML

Fixes #120 