### PR TITLE
Remove arrow-parens rule

### DIFF
--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -13,8 +13,7 @@
   "rules": {
     "no-shadow": "off",
     "no-param-reassign": "off",
-    "eol-last": "off",
-    "arrow-parens": "off"
+    "eol-last": "off"
   },
   "ignorePatterns": [
     "dist/",

--- a/react-redux/.eslintrc.json
+++ b/react-redux/.eslintrc.json
@@ -18,8 +18,7 @@
     "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
     "react/react-in-jsx-scope": "off",
     "import/no-unresolved": "off",
-    "no-shadow": "off",
-    "arrow-parens": ["error", "as-needed"]
+    "no-shadow": "off"
   },
   "ignorePatterns": [
     "dist/",


### PR DESCRIPTION
Removed [`arrow-parens`](https://eslint.org/docs/rules/arrow-parens) rule from React-Redux configuration
on JavaScript, it's set to off, but since it's off by default (tested), I removed the line as well.

Fixes #135 