### PR TITLE
Bump up outdated packages

### DIFF
--- a/html-css/.github/workflows/linters.yml
+++ b/html-css/.github/workflows/linters.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: "12.x"
       - name: Setup Lighthouse
-        run: npm install -g @lhci/cli@0.4.x
+        run: npm install -g @lhci/cli@0.7.x
       - name: Lighthouse Report
         run: lhci autorun --upload.target=temporary-public-storage --collect.staticDistDir=.
   webhint:
@@ -28,7 +28,7 @@ jobs:
           node-version: "12.x"
       - name: Setup Webhint
         run: |
-          npm install --save-dev hint@6.0.x
+          npm install --save-dev hint@6.x
           [ -f .hintrc ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/html-css/.hintrc
       - name: Webhint Report
         run: npx hint --telemetry=off .
@@ -42,7 +42,7 @@ jobs:
           node-version: "12.x"
       - name: Setup Stylelint
         run: |
-          npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+          npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x
           [ -f .stylelintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/html-css/.stylelintrc.json
       - name: Stylelint Report
         run: npx stylelint "**/*.{css,scss}"

--- a/html-css/README.md
+++ b/html-css/README.md
@@ -49,7 +49,7 @@ A customizable linting tool that helps you improve your site's accessibility, sp
 
 1. Run
    ```
-   npm install --save-dev hint@6.0.x
+   npm install --save-dev hint@6.x
    ```
    (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
 2. Copy [.hintrc](.hintrc) to the root directory of your project.
@@ -68,7 +68,7 @@ A mighty, modern linter that helps you avoid errors and enforce conventions in y
 1. Run
 
    ```
-   npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+   npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x
    ```
 
    (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).

--- a/javascript/.github/workflows/linters.yml
+++ b/javascript/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: "12.x"
       - name: Setup ESLint
         run: |
-          npm install --save-dev eslint@6.8.x eslint-config-airbnb-base@14.1.x eslint-plugin-import@2.20.x babel-eslint@10.1.x
+          npm install --save-dev eslint@7.x eslint-config-airbnb-base@14.x eslint-plugin-import@2.x babel-eslint@10.x
           [ -f .eslintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/javascript/.eslintrc.json
       - name: ESLint Report
         run: npx eslint .
@@ -30,7 +30,7 @@ jobs:
           node-version: "12.x"
       - name: Setup Stylelint
         run: |
-          npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+          npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x
           [ -f .stylelintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/javascript/.stylelintrc.json
       - name: Stylelint Report
         run: npx stylelint "**/*.{css,scss}"

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -36,7 +36,7 @@ node_modules/
 
 ### ESLint
 
-1. Run `npm install --save-dev eslint@6.8.x eslint-config-airbnb-base@14.1.x eslint-plugin-import@2.20.x babel-eslint@10.1.x` (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
+1. Run `npm install --save-dev eslint@7.x eslint-config-airbnb-base@14.x eslint-plugin-import@2.x babel-eslint@10.x` (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
 2. Copy [.eslintrc.json](./.eslintrc.json) to the root directory of your project.
 3. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**
     - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
@@ -49,7 +49,7 @@ node_modules/
 1. Run
 
    ```
-   npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+   npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x
    ```
 
    (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).

--- a/react-redux/.github/workflows/linters.yml
+++ b/react-redux/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: "12.x"
       - name: Setup ESLint
         run: |
-          npm install --save-dev eslint@7.11.x eslint-config-airbnb@18.2.x eslint-plugin-import@2.22.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@4.1.x babel-eslint@10.1.x
+          npm install --save-dev eslint@7.x eslint-config-airbnb@18.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x eslint-plugin-react-hooks@4.x @babel/eslint-parser@7.x
           [ -f .eslintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/react-redux/.eslintrc.json
       - name: ESLint Report
         run: npx eslint .
@@ -30,7 +30,7 @@ jobs:
           node-version: "12.x"
       - name: Setup Stylelint
         run: |
-          npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+          npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x
           [ -f .stylelintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/react-redux/.stylelintrc.json
       - name: Stylelint Report
         run: npx stylelint "**/*.{css,scss}"

--- a/react-redux/.github/workflows/linters.yml
+++ b/react-redux/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: "12.x"
       - name: Setup ESLint
         run: |
-          npm install --save-dev eslint@7.11.x eslint-config-airbnb@18.1.x eslint-plugin-import@2.22.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@2.5.x babel-eslint@10.1.x
+          npm install --save-dev eslint@7.11.x eslint-config-airbnb@18.2.x eslint-plugin-import@2.22.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@4.1.x babel-eslint@10.1.x
           [ -f .eslintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/react-redux/.eslintrc.json
       - name: ESLint Report
         run: npx eslint .

--- a/react-redux/README.md
+++ b/react-redux/README.md
@@ -29,7 +29,7 @@ Click on the `Details` link to see the full output and the errors that need to b
 
 ### ESLint
 
-1. Run `npm install --save-dev eslint@7.11.x eslint-config-airbnb@18.2.x eslint-plugin-import@2.22.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@4.1.x babel-eslint@10.1.x` (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
+1. Run `npm install --save-dev eslint@7.x eslint-config-airbnb@18.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x eslint-plugin-react-hooks@4.x @babel/eslint-parser@7.x` (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
 2. Copy [.eslintrc.json](./.eslintrc.json) to the root directory of your project.
 3. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**
     - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
@@ -42,7 +42,7 @@ Click on the `Details` link to see the full output and the errors that need to b
 1. Run
 
    ```
-   npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+   npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x
    ```
 
    (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).

--- a/react-redux/README.md
+++ b/react-redux/README.md
@@ -29,7 +29,7 @@ Click on the `Details` link to see the full output and the errors that need to b
 
 ### ESLint
 
-1. Run `npm install --save-dev eslint@7.11.x eslint-config-airbnb@18.1.x eslint-plugin-import@2.22.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@2.5.x babel-eslint@10.1.x` (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
+1. Run `npm install --save-dev eslint@7.11.x eslint-config-airbnb@18.2.x eslint-plugin-import@2.22.x eslint-plugin-jsx-a11y@6.2.x eslint-plugin-react@7.20.x eslint-plugin-react-hooks@4.1.x babel-eslint@10.1.x` (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).
 2. Copy [.eslintrc.json](./.eslintrc.json) to the root directory of your project.
 3. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**
     - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.

--- a/ror/.github/workflows/linters.yml
+++ b/ror/.github/workflows/linters.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 3.0.x
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'~>0.81.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop:'>= 1.0, < 2.0' # https://docs.rubocop.org/en/stable/installation/
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ror/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color
@@ -30,7 +30,7 @@ jobs:
           node-version: "12.x"
       - name: Setup Stylelint
         run: |
-          npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+          npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x
           [ -f .stylelintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ror/.stylelintrc.json
       - name: Stylelint Report
         run: npx stylelint "**/*.{css,scss}"

--- a/ror/.github/workflows/linters.yml
+++ b/ror/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
           ruby-version: 3.0.x
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'>= 1.0', '< 2.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop -v '>= 1.0, < 2.0' # https://docs.rubocop.org/en/stable/installation/
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ror/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color

--- a/ror/.github/workflows/linters.yml
+++ b/ror/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
           ruby-version: 3.0.x
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'>= 1.0, < 2.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop:'>= 1.0', '< 2.0' # https://docs.rubocop.org/en/stable/installation/
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ror/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color

--- a/ror/.rubocop.yml
+++ b/ror/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: enable
   Exclude:
     - "db/**/*"
     - "bin/*" 
@@ -24,7 +25,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
-  ExcludedMethods: ['describe']
+  IgnoredMethods: ['describe']
   Max: 30
 
 Style/Documentation:

--- a/ror/README.md
+++ b/ror/README.md
@@ -36,7 +36,7 @@ node_modules/
 
 ### Rubocop
 
-1. Add `gem 'rubocop', '~>0.81.0'` to `Gemfile` (not sure how to use Gemfile? Read [this](https://bundler.io/v1.15/guides/bundler_setup.html)).
+1. Add `gem 'rubocop', '>= 1.0, < 2.0'` to `Gemfile` (not sure how to use Gemfile? Read [this](https://bundler.io/v1.15/guides/bundler_setup.html)).
 2. Run `bundle install`.
 3. Copy [.rubocop.yml](./.rubocop.yml) to the root directory of your project
 4. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**
@@ -50,7 +50,7 @@ node_modules/
 1. Run
 
    ```
-   npm install --save-dev stylelint@13.3.x stylelint-scss@3.17.x stylelint-config-standard@20.0.x stylelint-csstree-validator
+   npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x
    ```
 
    (not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)).

--- a/ror/README.md
+++ b/ror/README.md
@@ -36,7 +36,7 @@ node_modules/
 
 ### Rubocop
 
-1. Add `gem 'rubocop', '>= 1.0, < 2.0'` to `Gemfile` (not sure how to use Gemfile? Read [this](https://bundler.io/v1.15/guides/bundler_setup.html)).
+1. Add `gem 'rubocop', '>= 1.0', '< 2.0'` to `Gemfile` (not sure how to use Gemfile? Read [this](https://bundler.io/v1.15/guides/bundler_setup.html)).
 2. Run `bundle install`.
 3. Copy [.rubocop.yml](./.rubocop.yml) to the root directory of your project
 4. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**

--- a/ruby/.github/workflows/linters.yml
+++ b/ruby/.github/workflows/linters.yml
@@ -14,7 +14,7 @@ jobs:
           ruby-version: ">=3.0.x"
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'>= 1.0, < 2.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop:'>= 1.0', '< 2.0' # https://docs.rubocop.org/en/stable/installation/
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ruby/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color

--- a/ruby/.github/workflows/linters.yml
+++ b/ruby/.github/workflows/linters.yml
@@ -11,10 +11,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: ">=2.6.x"
+          ruby-version: ">=3.0.x"
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'~>1.9.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop:'>= 1.0, < 2.0' # https://docs.rubocop.org/en/stable/installation/
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ruby/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color

--- a/ruby/.github/workflows/linters.yml
+++ b/ruby/.github/workflows/linters.yml
@@ -14,7 +14,7 @@ jobs:
           ruby-version: ">=3.0.x"
       - name: Setup Rubocop
         run: |
-          gem install --no-document rubocop:'>= 1.0', '< 2.0' # https://docs.rubocop.org/en/stable/installation/
+          gem install --no-document rubocop -v '>= 1.0, < 2.0' # https://docs.rubocop.org/en/stable/installation/
           [ -f .rubocop.yml ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/ruby/.rubocop.yml
       - name: Rubocop Report
         run: rubocop --color

--- a/ruby/.github/workflows/tests.yml
+++ b/ruby/.github/workflows/tests.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Setup RSpec
         run: |
           [ -f Gemfile ] && bundle
-          gem install --no-document rspec:'>=3.0', '< 4.0'
+          gem install --no-document rspec -v '>=3.0, < 4.0'
       - name: RSpec Report
         run: rspec --force-color --format documentation

--- a/ruby/.github/workflows/tests.yml
+++ b/ruby/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 3.0.x
       - name: Setup RSpec
         run: |
           [ -f Gemfile ] && bundle
-          gem install --no-document rspec:'~>3.0'
+          gem install --no-document rspec:'>=3.0, < 4.0'
       - name: RSpec Report
         run: rspec --force-color --format documentation

--- a/ruby/.github/workflows/tests.yml
+++ b/ruby/.github/workflows/tests.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Setup RSpec
         run: |
           [ -f Gemfile ] && bundle
-          gem install --no-document rspec:'>=3.0, < 4.0'
+          gem install --no-document rspec:'>=3.0', '< 4.0'
       - name: RSpec Report
         run: rspec --force-color --format documentation

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -44,7 +44,7 @@ Click on the `Details` link of the test action to check the results of your test
 
 ### [RuboCop](https://docs.rubocop.org/en/stable/)
 
-1. Add `gem 'rubocop', '~>0.81.0'` to `Gemfile` (not sure how to use Gemfile? Read [this](https://bundler.io/v1.15/guides/bundler_setup.html)).
+1. Add `gem 'rubocop', '>= 1.0, < 2.0'` to `Gemfile` (not sure how to use Gemfile? Read [this](https://bundler.io/v1.15/guides/bundler_setup.html)).
 2. Run `bundle install`.
 3. Copy [.rubocop.yml](./.rubocop.yml) to the root directory of your project
 4. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -44,7 +44,7 @@ Click on the `Details` link of the test action to check the results of your test
 
 ### [RuboCop](https://docs.rubocop.org/en/stable/)
 
-1. Add `gem 'rubocop', '>= 1.0, < 2.0'` to `Gemfile` (not sure how to use Gemfile? Read [this](https://bundler.io/v1.15/guides/bundler_setup.html)).
+1. Add `gem 'rubocop', '>= 1.0', '< 2.0'` to `Gemfile` (not sure how to use Gemfile? Read [this](https://bundler.io/v1.15/guides/bundler_setup.html)).
 2. Run `bundle install`.
 3. Copy [.rubocop.yml](./.rubocop.yml) to the root directory of your project
 4. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**


### PR DESCRIPTION
We've had to update ESLint for React so it works with the latest version of it (see #109), but there are 2 packages that should've also been updated to work with the new ESLint version. for some reason, they worked fine on `npm@6`, but not on `npm@7`.

Updated `eslint-plugin-react-hooks@2.5.x` to `eslint-plugin-react-hooks@4.1.x` [[see changelog](https://github.com/facebook/react/blob/master/packages/eslint-plugin-react-hooks/CHANGELOG.md)]
Updated `eslint-config-airbnb@18.1.x` to `eslint-config-airbnb@18.2.x` [[see changelog](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/CHANGELOG.md)]

I've also **updated all packages** to their latest version so they work with new Node or Ruby versions.

tested and everything should work fine.

Fixes #141