### PR TITLE
Extend CSS dictionary to recognize fit-content property for width

### DIFF
--- a/html-css/.stylelintrc.json
+++ b/html-css/.stylelintrc.json
@@ -4,7 +4,11 @@
   "rules": {
     "at-rule-no-unknown": null,
     "scss/at-rule-no-unknown": true,
-    "csstree/validator": true
+    "csstree/validator": {
+      "properties": {
+        "width": "| fit-content"
+      }
+    }
   },
   "ignoreFiles": ["build/**", "dist/**", "**/reset*.css", "**/bootstrap*.css"]
 }


### PR DESCRIPTION
This pull request is a follow-up to [this issue](https://github.com/microverseinc/linters-config/issues/131#issuecomment-804955908). The changes have been implemented.