### PR TITLE
Ignore JS and JSX files on Stylelint

### DIFF
--- a/react-redux/.stylelintrc.json
+++ b/react-redux/.stylelintrc.json
@@ -6,5 +6,5 @@
     "scss/at-rule-no-unknown": true,
     "csstree/validator": true
   },
-  "ignoreFiles": ["build/**", "dist/**", "**/reset*.css", "**/bootstrap*.css"]
+  "ignoreFiles": ["build/**", "dist/**", "**/reset*.css", "**/bootstrap*.css", "**/*.js", "**/*.jsx"]
 }


### PR DESCRIPTION
this PR adds .js and .jsx files to the ignore list of Stylelint configurations on the React project, this normally wouldn't be an issue, but if you're using an extension to check stylelint errors, it might give false-positive errors.
learn more on #145 


Fixes #145 