### PR TITLE
Include JSX files to the Eslint check

### DIFF
--- a/react-redux/.eslintrc.json
+++ b/react-redux/.eslintrc.json
@@ -12,6 +12,11 @@
     "ecmaVersion": 2018,
     "sourceType": "module"
   },
+  "overrides": [
+    {
+      "files": ["*.jsx", "*.js"]
+    }
+  ],
   "extends": ["airbnb", "plugin:react/recommended"],
   "plugins": ["react"],
   "rules": {


### PR DESCRIPTION
# The proposal

React includes a bunch of cool features, one of them is the introduction of JSX files for better formating.
JSX files have some advantages, including the ability to use emmet shortcuts, just like in plain HTML.

The actual Eslint configuration does not track JSX files which means we are not able to use the auto-fix feature.
## changes made: 

https://github.com/MacCrazyman/linters-config/blob/6485ba86a90de74895a44311d0c8977dfbb9276d/react-redux/.eslintrc.json#L15-L19

This allows the Eslint to track JSX files and perform the auto-fix function as well.

### ✔️ Tested and working
![Capture](https://user-images.githubusercontent.com/87956045/149844467-db57d5a6-da00-4b52-a783-74d6c6a9fc6f.PNG)
.