### PR TITLE
Update `./ror/stylelintrc.json` for tailwind 

### DIFF
--- a/ror/.stylelintrc.json
+++ b/ror/.stylelintrc.json
@@ -3,7 +3,11 @@
   "plugins": ["stylelint-scss", "stylelint-csstree-validator"],
   "rules": {
     "at-rule-no-unknown": null,
-    "scss/at-rule-no-unknown": true,
+    "scss/at-rule-no-unknown": [true,
+                                {
+                                  "ignoreAtRules": ["tailwind", "apply", "variants", "responsive", "screen"]
+                                }
+                               ],
     "csstree/validator": true
   },
   "ignoreFiles": ["build/**", "dist/**", "**/reset*.css", "**/bootstrap*.css"]

--- a/ror/.stylelintrc.json
+++ b/ror/.stylelintrc.json
@@ -2,12 +2,30 @@
   "extends": ["stylelint-config-standard"],
   "plugins": ["stylelint-scss", "stylelint-csstree-validator"],
   "rules": {
-    "at-rule-no-unknown": null,
-    "scss/at-rule-no-unknown": [true,
-                                {
-                                  "ignoreAtRules": ["tailwind", "apply", "variants", "responsive", "screen"]
-                                }
-                               ],
+    "at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": [
+          "tailwind",
+          "apply",
+          "variants",
+          "responsive",
+          "screen"
+        ]
+      }
+    ],
+    "scss/at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": [
+          "tailwind",
+          "apply",
+          "variants",
+          "responsive",
+          "screen"
+        ]
+      }
+    ],
     "csstree/validator": true
   },
   "ignoreFiles": ["build/**", "dist/**", "**/reset*.css", "**/bootstrap*.css"]


### PR DESCRIPTION
Update `scss/at-rule-no-unknown` rule to accept tailwind directives.

PR examples
 
with old config : https://github.com/od-c0d3r/tailwind-rails/runs/5581436235?check_suite_focus=true

win new config : https://github.com/od-c0d3r/tailwind-rails/runs/5581642045?check_suite_focus=true

**Note:** to test 

1. Follow tailwind [instructions](https://tailwindcss.com/docs/guides/ruby-on-rails) to create a rails project
2. There is an [issue](https://youtrack.jetbrains.com/issue/RUBY-29159) with tailwind build in Rails 7 so after using tailwind classes make sure to run `rails tailwindcss:build` to package your styles