### PR TITLE
Node modules check job

### DIFF
--- a/javascript/.github/workflows/linters.yml
+++ b/javascript/.github/workflows/linters.yml
@@ -34,3 +34,11 @@ jobs:
           [ -f .stylelintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/javascript/.stylelintrc.json
       - name: Stylelint Report
         run: npx stylelint "**/*.{css,scss}"
+  nodechecker:
+    name: node_modules checker
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check node_modules existence
+        run: |
+          if [ -d "node_modules/" ]; then echo "Directory node_modules/ was pushed to the repo.  Please delete it and try again." && exit 1; fi

--- a/javascript/.github/workflows/linters.yml
+++ b/javascript/.github/workflows/linters.yml
@@ -41,4 +41,4 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check node_modules existence
         run: |
-          if [ -d "node_modules/" ]; then echo -e "\e[1;31mThe node_modules/ folder was pushed to the repo. Please remove it from the GitHub repository and try again."; echo "You can set up a .gitignore file with this folder included on it to prevent this from happening in the future." && exit 1; fi
+          if [ -d "node_modules/" ]; then echo -e "\e[1;31mThe node_modules/ folder was pushed to the repo. Please remove it from the GitHub repository and try again."; echo -e "\e[1;31mYou can set up a .gitignore file with this folder included on it to prevent this from happening in the future." && exit 1; fi

--- a/javascript/.github/workflows/linters.yml
+++ b/javascript/.github/workflows/linters.yml
@@ -41,4 +41,4 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check node_modules existence
         run: |
-          if [ -d "node_modules/" ]; then echo "Directory node_modules/ was pushed to the repo.  Please delete it and try again." && exit 1; fi
+          if [ -d "node_modules/" ]; then echo -e "\e[1;31mThe node_modules/ folder was pushed to the repo. Please remove it from the GitHub repository and try again."; echo "You can set up a .gitignore file with this folder included on it to prevent this from happening in the future." && exit 1; fi

--- a/javascript/.github/workflows/linters.yml
+++ b/javascript/.github/workflows/linters.yml
@@ -41,4 +41,4 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check node_modules existence
         run: |
-          if [ -d "node_modules/" ]; then echo -e "\e[1;31mThe node_modules/ folder was pushed to the repo. Please remove it from the GitHub repository and try again."; echo -e "\e[1;31mYou can set up a .gitignore file with this folder included on it to prevent this from happening in the future." && exit 1; fi
+          if [ -d "node_modules/" ]; then echo -e "\e[1;31mThe node_modules/ folder was pushed to the repo. Please remove it from the GitHub repository and try again."; echo -e "\e[1;32mYou can set up a .gitignore file with this folder included on it to prevent this from happening in the future." && exit 1; fi


### PR DESCRIPTION
In this PR I:

- Created a GitHub action job that checks the existence of a `node_modules` folder on the PR.
- If the folder exists, it fails and exits with exit code 1.
- If the folder does not exist, it passes the check.
- For the students, I added the reason for the error in red color and the possible solution (.gitignore) in green.

This is a possible solution for the problem that occurs when a student forgets to set up a `.gitignore` file, and inadvertently pushes the `node_modules` folder to the repo.  

Since the `node_modules` folder pushes more than 5000 files to the PR, this was causing some of the CR computers to slow to a crawl, preventing them to write proper, explanatory invalidation messages.

With this GitHub workflow, students will be reminded to not push the `node_modules` folder and asked to delete it on the repo, because the linters won't pass.

![image](https://user-images.githubusercontent.com/57421823/167138680-a3bf76ca-4ed1-4906-98e7-42409ace3eb6.png)

![image](https://user-images.githubusercontent.com/57421823/167138699-0930aaa7-57f7-478f-8565-0517e0138ecb.png)

![image](https://user-images.githubusercontent.com/57421823/167138713-774d3b3c-1a1d-4a55-8da7-cd6edfcb39db.png)

