### PR TITLE
Update webhint to version 7

### DIFF
--- a/html-css-js/.github/workflows/linters.yml
+++ b/html-css-js/.github/workflows/linters.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: "12.x"
       - name: Setup Webhint
         run: |
-          npm install --save-dev hint@6.x
+          npm install --save-dev hint@7.x
           [ -f .hintrc ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/html-css-js/.hintrc
       - name: Webhint Report
         run: npx hint .

--- a/html-css-js/README.md
+++ b/html-css-js/README.md
@@ -54,7 +54,7 @@ A customizable linting tool that helps you improve your site's accessibility, sp
 
 1. Run
    ```
-   npm install --save-dev hint@6.x
+   npm install --save-dev hint@7.x
    ```
    *not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).*
 2. Copy [.hintrc](.hintrc) to the root directory of your project.

--- a/html-css/.github/workflows/linters.yml
+++ b/html-css/.github/workflows/linters.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: "12.x"
       - name: Setup Webhint
         run: |
-          npm install --save-dev hint@6.x
+          npm install --save-dev hint@7.x
           [ -f .hintrc ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/html-css/.hintrc
       - name: Webhint Report
         run: npx hint .

--- a/html-css/README.md
+++ b/html-css/README.md
@@ -54,7 +54,7 @@ A customizable linting tool that helps you improve your site's accessibility, sp
 
 1. Run
    ```
-   npm install --save-dev hint@6.x
+   npm install --save-dev hint@7.x
    ```
    *not sure how to use npm? Read [this](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).*
 2. Copy [.hintrc](.hintrc) to the root directory of your project.


### PR DESCRIPTION
We are currently using version 6 of webhint and some dependencies cannot be met for this version.  ([Case 1](https://github.com/Abdullah2213565/Portfolio-Project-1/pull/10)) ([Case 2](https://github.com/sharon-odhiambo/My-Portfolio-Site/pull/8)) ([Case 3](https://github.com/Pamphilemkp/My_professional_portfolio/pull/11))
The 7th version of webhint doesn’t have the same issue.
This PR updates webhint version to 7 to prevent this issues