### PR TITLE
Update `runs-on` configuration for all jobs

### DIFF
--- a/html-css-js/.github/workflows/linters.yml
+++ b/html-css-js/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   lighthouse:
     name: Lighthouse
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -20,7 +20,7 @@ jobs:
         run: lhci autorun --upload.target=temporary-public-storage --collect.staticDistDir=.
   webhint:
     name: Webhint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -34,7 +34,7 @@ jobs:
         run: npx hint .
   stylelint:
     name: Stylelint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -48,7 +48,7 @@ jobs:
         run: npx stylelint "**/*.{css,scss}"
   eslint:
     name: ESLint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -62,7 +62,7 @@ jobs:
         run: npx eslint .
   nodechecker:
     name: node_modules checker
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Check node_modules existence

--- a/html-css/.github/workflows/linters.yml
+++ b/html-css/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   lighthouse:
     name: Lighthouse
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -20,7 +20,7 @@ jobs:
         run: lhci autorun --upload.target=temporary-public-storage --collect.staticDistDir=.
   webhint:
     name: Webhint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -34,7 +34,7 @@ jobs:
         run: npx hint .
   stylelint:
     name: Stylelint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -48,7 +48,7 @@ jobs:
         run: npx stylelint "**/*.{css,scss}"
   nodechecker:
     name: node_modules checker
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Check node_modules existence

--- a/javascript/.github/workflows/linters.yml
+++ b/javascript/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   eslint:
     name: ESLint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -22,7 +22,7 @@ jobs:
         run: npx eslint .
   stylelint:
     name: Stylelint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -36,7 +36,7 @@ jobs:
         run: npx stylelint "**/*.{css,scss}"
   nodechecker:
     name: node_modules checker
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Check node_modules existence

--- a/react-redux/.github/workflows/linters.yml
+++ b/react-redux/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   eslint:
     name: ESLint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -23,7 +23,7 @@ jobs:
         run: npx eslint .
   stylelint:
     name: Stylelint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -37,7 +37,7 @@ jobs:
         run: npx stylelint "**/*.{css,scss}"
   nodechecker:
     name: node_modules checker
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Check node_modules existence

--- a/ror/.github/workflows/linters.yml
+++ b/ror/.github/workflows/linters.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   rubocop:
     name: Rubocop
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1
@@ -22,7 +22,7 @@ jobs:
         run: rubocop --color
   stylelint:
     name: Stylelint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -36,7 +36,7 @@ jobs:
         run: npx stylelint "**/*.{css,scss}"
   nodechecker:
     name: node_modules checker
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Check node_modules existence

--- a/ruby/.github/workflows/linters.yml
+++ b/ruby/.github/workflows/linters.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   rubocop:
     name: Rubocop
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     
     steps:
       - uses: actions/checkout@v2

--- a/ruby/.github/workflows/tests.yml
+++ b/ruby/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   rspec:
     name: RSpec
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-ruby@v1


### PR DESCRIPTION
## Update OS for all actions running on Ubuntu

20 days ago [GitHub actions](https://github.com/actions/runner-images/issues/6002#issue-1325639357) announced that the `Ubuntu 18.04` os is no longer supported, and it will be fully deprecated on 12/1/2022. Until then all the actions that run on `Ubuntu 18.04` will be queued for some time.

The fix that I introduced is to change all `runs-on: ubuntu-**-**` into `runs-on: ubuntu-latest` to avoid any future deprecation.

_related issue: #205_ 