### PR TITLE
Replace broken link.

### DIFF
--- a/html-css-js/README.md
+++ b/html-css-js/README.md
@@ -83,7 +83,7 @@ A mighty, modern linter that helps you avoid errors and enforce conventions in y
    - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
 4. Run `npx stylelint "**/*.{css,scss}"` on the root of your directory of your project.
 5. Fix linter errors.
-6. **IMPORTANT NOTE**: feel free to research [auto-correct options for Stylelint](https://stylelint.io/user-guide/cli#autofixing-errors) if you get a flood of errors but keep in mind that correcting style errors manually will help you to make a habit of writing a clean code!
+6. **IMPORTANT NOTE**: feel free to research [auto-correct options for Stylelint](https://stylelint.io/user-guide/usage/options) if you get a flood of errors but keep in mind that correcting style errors manually will help you to make a habit of writing a clean code!
 
 ### [ESLint](https://eslint.org/)
 
@@ -98,4 +98,4 @@ A mighty, modern linter that helps you avoid errors and enforce conventions in y
     - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
 4. Run `npx eslint .` on the root of your directory of your project.
 5. Fix linter errors.
-6. **IMPORTANT NOTE**: feel free to research [auto-correct options for Stylelint](https://stylelint.io/user-guide/cli#autofixing-errors) if you get a flood of errors but keep in mind that correcting style errors manually will help you to make a habit of writing a clean code!
+6. **IMPORTANT NOTE**: feel free to research [auto-correct options for Eslint](https://eslint.org/docs/latest/user-guide/command-line-interface#fixing-problems) if you get a flood of errors but keep in mind that correcting style errors manually will help you to make a habit of writing a clean code!


### PR DESCRIPTION
@nidalaa, 

This link [auto-correct options for Stylelint](https://stylelint.io/user-guide/cli#autofixing-errors) seems not working anymore, I replace it with a helpful link.
Fix a typo and added Eslint auto-fix documentation link.

If you're ok with the PR, kindly approve. I will update the rest of the files that need correction. 