### PR TITLE
Update rubocop yml for obsolete methods

### DIFF
--- a/ror/.rubocop.yml
+++ b/ror/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 150
 Metrics/BlockLength:
-  IgnoredMethods: ['describe']
+  AllowedMethods: ['describe']
   Max: 30
 
 Style/Documentation:


### PR DESCRIPTION
When you run rubocop it sets out a warning: 

"obsolete parameter `IgnoredMethods` (for `Metrics/BlockLength`) found in .rubocop.yml `IgnoredMethods` has been renamed to `AllowedMethods` and/or `AllowedPatterns`."

![image](https://user-images.githubusercontent.com/59999191/209404601-fdd8ac7d-c3d5-41f4-9de3-cad6ff7a2e15.png)


This fix removes the warning and allows the user to concentrate on the report.