### PR TITLE
Specify jsx and js check

### DIFF
--- a/react-redux/.github/workflows/linters.yml
+++ b/react-redux/.github/workflows/linters.yml
@@ -20,7 +20,7 @@ jobs:
           [ -f .eslintrc.json ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/react-redux/.eslintrc.json
           [ -f .babelrc ] || wget https://raw.githubusercontent.com/microverseinc/linters-config/master/react-redux/.babelrc
       - name: ESLint Report
-        run: npx eslint .
+        run: npx eslint "**/*.{js,jsx}"
   stylelint:
     name: Stylelint
     runs-on: ubuntu-22.04

--- a/react-redux/README.md
+++ b/react-redux/README.md
@@ -37,7 +37,7 @@ Click on the `Details` link to see the full output and the errors that need to b
 2. Copy [.eslintrc.json](./.eslintrc.json) and [.babelrc](./.babelrc) to the root directory of your project.
 3. **Do not make any changes in config files - they represent style guidelines that you share with your team - which is a group of all Microverse students.**
     - If you think that change is necessary - open a [Pull Request in this repository](../README.md#contributing) and let your code reviewer know about it.
-4. Run `npx eslint .` on the root of your directory of your project.
+4. Run `npx eslint "**/*.{js,jsx}"` on the root of your directory of your project.
 5. Fix linter errors.
 6. **IMPORTANT NOTE**: feel free to research [auto-correct options for Eslint](https://eslint.org/docs/latest/user-guide/command-line-interface#fixing-problems) if you get a flood of errors but keep in mind that correcting style errors manually will help you to make a habit of writing a clean code!
 


### PR DESCRIPTION
Our current linter config for React-Redux doesn't catch any error in `jsx` file. [PR](https://github.com/Htetaungkyaw71/BookStore-React/pull/3) example

For some reason, `jsx` file extension is ignored.

I update these files to specify `jsx` and also update the README file for students to be able to run the command locally.