### PR TITLE
Modified the node version of the linters for works with Git Hub Actions

### DIFF
--- a/html-css/.github/workflows/linters.yml
+++ b/html-css/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: "18.x"
+          node-version: "12.x"
       - name: Setup Lighthouse
         run: npm install -g @lhci/cli@0.7.x
       - name: Lighthouse Report
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: "18.x"
+          node-version: "16.x"
       - name: Setup Webhint
         run: |
           npm install --save-dev hint@7.x
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: "18.x"
+          node-version: "12.x"
       - name: Setup Stylelint
         run: |
           npm install --save-dev stylelint@13.x stylelint-scss@3.x stylelint-config-standard@21.x stylelint-csstree-validator@1.x


### PR DESCRIPTION
Modified the node version for work in module 1 first exercise from microverse, seems that we must use another different node version for works with git hub actions.
the config that works for me was:
Lighthouse: 12.x
Webhint: 16.x
Stylelint 12.x
I hope that you encounter this info very useful.