### PR TITLE
Clarify RTK file pattern for ESLint

### DIFF
--- a/react-redux/.eslintrc.json
+++ b/react-redux/.eslintrc.json
@@ -22,6 +22,7 @@
   },
   "overrides": [
     {
+       // feel free to replace with your preferred file pattern - eg. 'src/**/*Slice.js' or 'redux/**/*Slice.js'
       "files": ["src/**/*Slice.js"],
       // avoid state param assignment
       "rules": { "no-param-reassign": ["error", { "props": false }] }


### PR DESCRIPTION
@NoerGitKat we need to cover other cases where the student has their slice.js in the redux folder or any other named folder.

For example: In this [PR](https://github.com/amejid/redux-demo/pull/1), the student got an error using `src`, so we need to tell them to always update their pattern accordingly.

Kindly review and merge.