### PR TITLE
Update .eslintrc.json

### DIFF
--- a/react-redux/.eslintrc.json
+++ b/react-redux/.eslintrc.json
@@ -18,14 +18,13 @@
     "react/jsx-filename-extension": ["warn", { "extensions": [".js", ".jsx"] }],
     "react/react-in-jsx-scope": "off",
     "import/no-unresolved": "off",
+    "no-param-reassign": "off"
     "no-shadow": "off"
   },
   "overrides": [
     {
-       // feel free to replace with your preferred file pattern - eg. 'src/**/*Slice.js' or 'redux/**/*Slice.js'
+      // feel free to replace with your preferred file pattern - eg. 'src/**/*Slice.js' or 'redux/**/*Slice.js'
       "files": ["src/**/*Slice.js"],
-      // avoid state param assignment
-      "rules": { "no-param-reassign": ["error", { "props": false }] }
     }
   ],
   "ignorePatterns": [


### PR DESCRIPTION
@NoerGitKat - Because we already declare the rules at [line 17](https://github.com/microverseinc/linters-config/blob/master/react-redux/.eslintrc.json#:~:text=react%22%5D%2C-,%22rules%22%3A%20%7B,-%22react/jsx%2Dfilename), we just need to add it in there.

Kindly review and merge if fine by you.