### PR TITLE
Update .eslintrc.json

### DIFF
--- a/html-css-js/.eslintrc.json
+++ b/html-css-js/.eslintrc.json
@@ -4,7 +4,7 @@
     "es6": true,
     "jest": true
   },
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"

--- a/javascript/.eslintrc.json
+++ b/javascript/.eslintrc.json
@@ -4,7 +4,7 @@
     "es6": true,
     "jest": true
   },
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
     "ecmaVersion": 2018,
     "sourceType": "module"


### PR DESCRIPTION
@NoerGitKat - `babel-eslint` is deprecarted. `babel-eslint` is now `@babel/eslint-parser`.

https://www.npmjs.com/package/babel-eslint

Kindly review and merge